### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # WayOfWorking::Audit::Github
 
+> [!IMPORTANT]
+> **This repository has been archived.**
+>
+> The GitHub Audit (audit_github) feature has been merged into the main [`way_of_working`](https://github.com/HealthDataInsight/way_of_working) gem, where it is now a built-in, opt-in feature. Enable it by requiring it:
+>
+> ```ruby
+> require 'way_of_working/audit/github'
+> ```
+>
+> Then use `way_of_working init audit_github` and `way_of_working exec audit_github` as before. This repository is no longer maintained.
+
 <!-- Way of Working: Main Badge Holder Start -->
 ![Way of Working Badge](https://img.shields.io/badge/Way_of_Working-v2.0.1-%238169e3?labelColor=black)
 <!-- Way of Working: Additional Badge Holder Start -->


### PR DESCRIPTION
This repository is being archived. The GitHub Audit (`audit_github`) feature has been merged into the main [`way_of_working`](https://github.com/HealthDataInsight/way_of_working) gem as a built-in, opt-in feature.

Adds an archive notice just below the README header pointing users to the new home and explaining how to enable the feature there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)